### PR TITLE
Handle the configuration for docker registries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires=install_requires(),
     extras_require={
         "dev": ["setuptools", "wheel"],
-        "test": ["coverage"],
+        "test": ["coverage", "pytest"],
     },
     python_requires=">=3.6, <4",
     package_dir={"": "src"},

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     },
     install_requires=install_requires(),
     extras_require={
-        "dev": ["setuptools", "wheel"],
+        "dev": ["setuptools", "wheel", "black"],
         "test": ["coverage", "pytest"],
     },
     python_requires=">=3.6, <4",

--- a/src/lennybot/config/config.py
+++ b/src/lennybot/config/config.py
@@ -28,6 +28,22 @@ CONFIGURATION_OPTIONS = {
         "type": "object",
         "properties": {"level": {"type": "string", "required": False, "attribute": "_logging_level"}},
     },
+    "container": {
+        "type": "object",
+        "attribute": "_container",
+        "properties": {
+            "registries": {
+                "type": "map", 
+                "required": False, 
+                "attribute": "_registries", 
+                "value_class": "LennyBotConfigContainerRegistry",
+                "properties": {
+                    "username": {"type": "string", "attribute": "_username"},
+                    "password": {"type": "string", "attribute": "_password"},
+                },
+            }
+        }
+    },
     "applications": {
         "type": "list",
         "required": True,
@@ -194,6 +210,33 @@ class LennyBotGithubPr:
     def branch_prefix(self) -> str:
         return self._branch_prefix
 
+class LennyBotConfigContainerRegistry:
+
+    def __init__(self, name) -> None:
+        self._name = name
+        self._username = None
+        self._password = None
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def username(self) -> str:
+        return self._username
+
+    @property
+    def password(self) -> str:
+        return self._password
+
+class LennyBotConfigContainerConfig:
+
+    def __init__(self) -> None:
+        self._registries = {}
+
+    @property
+    def registries(self) -> any:
+        return self._registries
 
 class LennyBotConfig:
     def __init__(self, filename) -> None:
@@ -204,6 +247,7 @@ class LennyBotConfig:
         self._github_token = None
         self._github_pr = LennyBotGithubPr()
         self._logging_level = "INFO"
+        self._container = LennyBotConfigContainerConfig()
         self._applications = []
         self._parse()
         self._configure_logging()
@@ -223,7 +267,7 @@ class LennyBotConfig:
             if name not in data.keys():
                 continue
             config_type = property["type"]
-            if config_type in ["object", "list"]:
+            if config_type in ["object", "list", "map"]:
                 self._parse_nested_data(name, property, data, target)
                 continue
             attribute_name = property["attribute"]
@@ -253,12 +297,35 @@ class LennyBotConfig:
                 self._parse_data(property["properties"], item, array_target)
                 getattr(target, attribute_name).append(array_target)
             return
+        if config_type == "map":
+            if "attribute" in property:
+                target = getattr(target, property["attribute"].split(".")[-1])
+            for key in data[name].keys():
+                map_target = globals()[property["value_class"]](key)
+                self._parse_data(property["properties"], data[name][key], map_target)
+                target[key] = map_target
+            return
 
     def _parse_env(self):
         if "LB_GITHUB_TOKEN" in os.environ.keys():
             self._github_token = os.environ["LB_GITHUB_TOKEN"]
         if "LB_STATE_FILE" in os.environ.keys():
             self._state_file = os.environ["LB_STATE_FILE"]
+        for key in os.environ.keys():
+            if not key.startswith('LB_CONTAINER_REGISTRY_'):
+                continue
+            parts = key.removeprefix('LB_CONTAINER_REGISTRY_').split("_")
+            registry = parts[0]
+            suffix = parts[1]
+            if registry not in self._container._registries:
+                raise Exception("REGISTRY NOT FOUND")
+            registry_data = self._container._registries[registry]
+            if suffix == "USERNAME":
+                registry_data._username = os.environ[key]
+            elif suffix == "PASSWORD":
+                registry_data._password = os.environ[key]
+            else:
+                raise Exception(f"Unknown suffix: {suffix}")
         # TODO make this generic
 
     @property

--- a/src/lennybot/config/config.py
+++ b/src/lennybot/config/config.py
@@ -33,16 +33,16 @@ CONFIGURATION_OPTIONS = {
         "attribute": "_container",
         "properties": {
             "registries": {
-                "type": "map", 
-                "required": False, 
-                "attribute": "_registries", 
+                "type": "map",
+                "required": False,
+                "attribute": "_registries",
                 "value_class": "LennyBotConfigContainerRegistry",
                 "properties": {
                     "username": {"type": "string", "attribute": "_username"},
                     "password": {"type": "string", "attribute": "_password"},
                 },
             }
-        }
+        },
     },
     "applications": {
         "type": "list",
@@ -210,8 +210,8 @@ class LennyBotGithubPr:
     def branch_prefix(self) -> str:
         return self._branch_prefix
 
-class LennyBotConfigContainerRegistry:
 
+class LennyBotConfigContainerRegistry:
     def __init__(self, name) -> None:
         self._name = name
         self._username = None
@@ -229,14 +229,15 @@ class LennyBotConfigContainerRegistry:
     def password(self) -> str:
         return self._password
 
-class LennyBotConfigContainerConfig:
 
+class LennyBotConfigContainerConfig:
     def __init__(self) -> None:
         self._registries = {}
 
     @property
     def registries(self) -> any:
         return self._registries
+
 
 class LennyBotConfig:
     def __init__(self, filename) -> None:
@@ -312,9 +313,9 @@ class LennyBotConfig:
         if "LB_STATE_FILE" in os.environ.keys():
             self._state_file = os.environ["LB_STATE_FILE"]
         for key in os.environ.keys():
-            if not key.startswith('LB_CONTAINER_REGISTRY_'):
+            if not key.startswith("LB_CONTAINER_REGISTRY_"):
                 continue
-            parts = key.removeprefix('LB_CONTAINER_REGISTRY_').split("_")
+            parts = key.removeprefix("LB_CONTAINER_REGISTRY_").split("_")
             registry = parts[0]
             suffix = parts[1]
             if registry not in self._container._registries:

--- a/src/lennybot/lennybot.py
+++ b/src/lennybot/lennybot.py
@@ -4,7 +4,7 @@ import pickle
 import subprocess
 from datetime import datetime
 
-from git import Repo, GitDB
+from git import GitDB, Repo
 
 from .actions import *
 from .config import LennyBotConfig

--- a/test/config/test_config.py
+++ b/test/config/test_config.py
@@ -1,0 +1,12 @@
+import unittest
+import os
+from lennybot.config import LennyBotConfig
+
+
+class TestLennyBotConfig(unittest.TestCase):
+
+    def test_XXX(self):
+        os.environ["LB_CONTAINER_REGISTRY_ghcr.io_USERNAME"] = "lucas"
+        config = LennyBotConfig("test/lennybot.yaml")
+        self.assertEqual(1, len(config._container._registries))
+        self.assertEqual("lucas", config._container.registries["ghcr.io"].username)

--- a/test/config/test_config.py
+++ b/test/config/test_config.py
@@ -1,10 +1,10 @@
-import unittest
 import os
+import unittest
+
 from lennybot.config import LennyBotConfig
 
 
 class TestLennyBotConfig(unittest.TestCase):
-
     def test_XXX(self):
         os.environ["LB_CONTAINER_REGISTRY_ghcr.io_USERNAME"] = "lucas"
         config = LennyBotConfig("test/lennybot.yaml")

--- a/test/lennybot.yaml
+++ b/test/lennybot.yaml
@@ -5,6 +5,11 @@ github:
     enabled: true
     repository: "repo/cloud-images"
     branchPrefix: "lennybot-"
+container:
+  registries:
+    ghcr.io:
+      username: "<REDACTED>"
+      password: "<REDACTED>"
 applications:
   - name: argocd
     source:


### PR DESCRIPTION
It would be nice to check the existence of images in private docker registries. Therefore credentials are needed to access this registries. This PR should provide the ability to pass these credentials to the lennybot via configuration file and environment variables.