### PR TITLE
fix regex pattern for image_registries

### DIFF
--- a/src/lennybot/check/docker_image_available.py
+++ b/src/lennybot/check/docker_image_available.py
@@ -8,7 +8,7 @@ import requests
 from ..config.config import LennyBotCheckConfig, LennyBotConfigContainerConfig, LennyBotConfigContainerRegistry
 from .icheck import ICheck
 
-PATTERN = r"(?:([\-\_\.\w]+)$)|(?:([\-\_\.\w]+)/([\-\_\.\w]+)$)|(?:([\-\.A-z0-9]+)/([\-\_\.\w]+)/([\-\_\.\w]+)$)"
+PATTERN = r"(?:([\-\_\.\w]+)$)|(?:([\-\_\.\w]+)/([\-\_\.\w]+)$)|(?:([\-\.A-z0-9]+)/([\-\_\.\w]+)/([\-\_\.\w]+)$)|(?:([\-\.A-z0-9]+)/([\-\_\.\w]+)/([\-\_\.\w]+)/([\-\_\.\w]+)$)"
 
 
 class DockerImage:
@@ -91,7 +91,10 @@ class DockerImageAvailableCheck(ICheck):
         if match.group(2) is not None:
             logging.debug("regex matched following pattern: " + match.group(2) + "/" + match.group(3) + " " + image_tag)
             return DockerImage(None, match.group(2) + "/" + match.group(3), image_tag)
-        return DockerImage(match.group(4), match.group(5) + "/" + match.group(6), image_tag)
+        if match.group(4) is not None:
+            logging.debug("regex matched following pattern: " + match.group(4) + "/" + match.group(5) + "/" + match.group(6) + " " + image_tag)
+            return DockerImage(match.group(4), match.group(5) + "/" + match.group(6), image_tag)
+        return DockerImage(match.group(7), match.group(8) + "/" + match.group(9) + "/" + match.group(10), image_tag)
 
     def _authenticate_on_registry(self, registry: str, authentication_header: WwwAuthenticateHeader) -> str:
         params = {

--- a/test/test_docker_image_available.py
+++ b/test/test_docker_image_available.py
@@ -35,8 +35,13 @@ class TestParseImage(unittest.TestCase):
         check = DockerImageAvailableCheck("test-app", "2.7.6", "2.7.7", self.config, self.container_config)
         self.assertRaises(Exception, check.check)
 
-    def test_given_toolong_image_path(self):
+    def test_given_image_path_with_4_segments(self):
         self.config._image_pattern = "quay.io/argo/proj/argocd:v{{version}}"
+        check = DockerImageAvailableCheck("test-app", "2.7.6", "2.7.7", self.config, self.container_config)
+        self.assertRaises(Exception, check.check)
+
+    def test_given_toolong_image_path(self):
+        self.config._image_pattern = "quay.io/argo/proj/argo/argocd:v{{version}}"
         check = DockerImageAvailableCheck("test-app", "2.7.6", "2.7.7", self.config, self.container_config)
         self.assertRaises(Exception, check.check)
 


### PR DESCRIPTION
fix regex pattern for registries with more than 2 slashes in the name, now should support 3 slashes.